### PR TITLE
🐛 fix (Home): eviter les doublons d'articles dans les section "Articles"

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -177,6 +177,7 @@ nodes {
 
 latestnews: allWpPost(
   limit: 3
+  skip: 3
   sort: {fields: [date], order: DESC}
   filter: {language: {code: {eq: EN}}, categories: {nodes: {elemMatch: {slug: {eq: "news"}}}}}
 
@@ -495,7 +496,7 @@ learn: allWpPost(
 }
    latestNewsExceptThree: allWpPost(
     limit: 3
-    skip: 3
+    skip: 6
     sort: {fields: [date], order: DESC}
     filter: {language: {code: {eq: EN}}, categories: {nodes: {elemMatch: {slug: {eq: "news"}}}}}
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -334,6 +334,7 @@ nodes {
 }
   latestnews: allWpPost(
     limit: 3
+    skip: 3
     sort: {fields: [date], order: DESC}
     filter: {language: {code: {eq: FR}}, categories: {nodes: {elemMatch: {slug: {eq: "actualites"}}}}}
 
@@ -663,7 +664,7 @@ slider: allWpPost(
   }
    latestNewsExceptThree: allWpPost(
     limit: 3
-    skip: 3
+    skip: 6
     sort: {fields: [date], order: DESC}
     filter: {language: {code: {eq: FR}}, categories: {nodes: {elemMatch: {slug: {eq: "actualites"}}}}}
 


### PR DESCRIPTION
Dans la page d'acceuil les articles recemment publiés apparraissent sur plusieurs sections
GraphQL utilisée sur la page d'accueil en excluant les articles déjà publiés de la section "Dernières Nouvelles". Cela améliore l'efficacité en empêchant l'affichage de contenus déjà consultés